### PR TITLE
Add `SKIP LOCKED` clause to DJ Pickup Query

### DIFF
--- a/lib/delayed/backend/active_record.rb
+++ b/lib/delayed/backend/active_record.rb
@@ -130,7 +130,7 @@ module Delayed
           # SQL for Postgres if we use a .limit() filter, but it would not
           # use 'FOR UPDATE' and we would have many locking conflicts
           quoted_name = connection.quote_table_name(table_name)
-          subquery    = ready_scope.limit(1).lock(true).select("id").to_sql
+          subquery    = ready_scope.limit(1).lock('FOR UPDATE SKIP LOCKED').select("id").to_sql
           sql         = "UPDATE #{quoted_name} SET locked_at = ?, locked_by = ? WHERE id IN (#{subquery}) RETURNING *"
           reserved    = find_by_sql([sql, now, worker.name])
           reserved[0]


### PR DESCRIPTION
This changes the optimized Postgres strategy to use the `SKIP LOCKED`
locking clause.

This is 'new' in Postgres 9.5, but thats pretty old for us. What it does
is change the locking behavior in this sub-query to do the pickup.
Before it would wait behind other locks, meaning that the more workers
were competing for jobs, the more locks were occuring.

This way new queries will just skip locked rows, and pick up the 'next'
available job!

Blog Post about SKIP LOCKED in queues: https://vladmihalcea.com/database-job-queue-skip-locked/
PR where QueueClassic adopted this: https://github.com/QueueClassic/queue_classic/pull/303
Postgres Docs: https://www.postgresql.org/docs/12/sql-select.html#SQL-FOR-UPDATE-SHARE